### PR TITLE
chore: Update pipeline configuration to use windows-latest

### DIFF
--- a/YAHW/functions/Invoke-YAHW.ps1
+++ b/YAHW/functions/Invoke-YAHW.ps1
@@ -1,5 +1,5 @@
 ﻿function Invoke-YAHW {
-<#
+    <#
     .SYNOPSIS
         Invoke Yet Another Hello World
 
@@ -13,14 +13,17 @@
         Invoke Yet Another Hello World
 #>
     [CmdletBinding()]
-    param ()
+    param (
+        [string]
+        $Text
+    )
 
     begin {
 
     }
 
     process {
-        Write-PSFMessage -Level Host -Message "Say hello World"
+        Write-PSFMessage -Level Host -Message "Say hello World $Text"
     }
 
     end {

--- a/YAHW/functions/Invoke-YAHW.ps1
+++ b/YAHW/functions/Invoke-YAHW.ps1
@@ -6,12 +6,14 @@
     .DESCRIPTION
         Invoke Yet Another Hello World
 
+    .PARAMETER Text
+        Additional text to display
 
     .EXAMPLE
         PS C:\> Invoke-YAHW
 
         Invoke Yet Another Hello World
-#>
+    #>
     [CmdletBinding()]
     param (
         [string]

--- a/build/azure_pipeline-validate.yml
+++ b/build/azure_pipeline-validate.yml
@@ -1,5 +1,5 @@
 pool:
-  name: "windows-latest"
+  vmImage: "windows-latest"
 
 # Continuous integration only on branch Development
 trigger:

--- a/build/azure_pipeline-validate.yml
+++ b/build/azure_pipeline-validate.yml
@@ -1,36 +1,36 @@
 pool:
-  name: Hosted VS2017
+  name: "windows-latest"
 
 # Continuous integration only on branch Development
 trigger:
   branches:
     include:
-    - Development
+      - Development
 
 # Pull request validation only on branch master & development
 pr:
   branches:
     include:
-    - master
-    - Development
+      - master
+      - Development
 
 steps:
-- task: PowerShell@2
-  displayName: Ensure prerequisites
-  inputs:
-    targetType: filePath
-    filePath: './build/vsts-prerequisites.ps1'
-    arguments: '-ModuleName $(system.teamProject)'
+  - task: PowerShell@2
+    displayName: Ensure prerequisites
+    inputs:
+      targetType: filePath
+      filePath: "./build/vsts-prerequisites.ps1"
+      arguments: "-ModuleName $(system.teamProject)"
 
-- task: PowerShell@2
-  displayName: Validate code compliance
-  inputs:
-    targetType: filePath
-    filePath: './build/vsts-validate.ps1'
-    arguments: '-ModuleName $(system.teamProject)'
+  - task: PowerShell@2
+    displayName: Validate code compliance
+    inputs:
+      targetType: filePath
+      filePath: "./build/vsts-validate.ps1"
+      arguments: "-ModuleName $(system.teamProject)"
 
-- task: PublishTestResults@2
-  displayName: 'Publish Test Results **/TEST-*.xml'
-  inputs:
-    testResultsFormat: NUnit
-  condition: always()
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results **/TEST-*.xml"
+    inputs:
+      testResultsFormat: NUnit
+    condition: always()

--- a/build/azure_pipeline-validate_and_Build.yml
+++ b/build/azure_pipeline-validate_and_Build.yml
@@ -1,41 +1,41 @@
 pool:
-  name: Hosted VS2017
+  name: "windows-latest"
 
 # Continuous integration only on branch master
 trigger:
   branches:
     include:
-    - master
-    - releases/*
+      - master
+      - releases/*
 
 # Pull request validation disabled
 pr: none
 
 # Job steps
 steps:
-- task: PowerShell@2
-  displayName: Ensure prerequisites
-  inputs:
-    targetType: filePath
-    filePath: './build/vsts-prerequisites.ps1'
-    arguments: '-ModuleName $(system.teamProject)'
+  - task: PowerShell@2
+    displayName: Ensure prerequisites
+    inputs:
+      targetType: filePath
+      filePath: "./build/vsts-prerequisites.ps1"
+      arguments: "-ModuleName $(system.teamProject)"
 
-- task: PowerShell@2
-  displayName: Validate code compliance
-  inputs:
-    targetType: filePath
-    filePath: './build/vsts-validate.ps1'
-    arguments: '-ModuleName $(system.teamProject)'
+  - task: PowerShell@2
+    displayName: Validate code compliance
+    inputs:
+      targetType: filePath
+      filePath: "./build/vsts-validate.ps1"
+      arguments: "-ModuleName $(system.teamProject)"
 
-- task: PowerShell@2
-  displayName: Build and publish module
-  inputs:
-    targetType: filePath
-    filePath: './build/vsts-build.ps1'
-    arguments: '-ModuleName $(system.teamProject) -ApiKey $(PSGalleryAPIKey) -AutoVersion'
+  - task: PowerShell@2
+    displayName: Build and publish module
+    inputs:
+      targetType: filePath
+      filePath: "./build/vsts-build.ps1"
+      arguments: "-ModuleName $(system.teamProject) -ApiKey $(PSGalleryAPIKey) -AutoVersion"
 
-- task: PublishTestResults@2
-  displayName: 'Publish Test Results **/TEST-*.xml'
-  inputs:
-    testResultsFormat: NUnit
-  condition: always()
+  - task: PublishTestResults@2
+    displayName: "Publish Test Results **/TEST-*.xml"
+    inputs:
+      testResultsFormat: NUnit
+    condition: always()


### PR DESCRIPTION
added super interesting text

chore: Update pipeline configuration to use windows-latest
Changed the pool name from Hosted VS2017 to windows-latest for better compatibility with current build environments.
Updated formatting for consistency and clarity in the azure_pipeline-validate.yml and azure_pipeline-validate_and_Build.yml files.